### PR TITLE
Disable buy buttons with 'coming soon' indication

### DIFF
--- a/app/creator/[id]/page.tsx
+++ b/app/creator/[id]/page.tsx
@@ -351,7 +351,7 @@ export default function CreatorPage() {
               </div>
 
               <div className="flex flex-col sm:flex-row gap-4 items-center justify-center md:justify-start">
-                <button className="bg-black text-white px-8 py-3 rounded-full font-semibold text-lg hover:bg-gray-800 transition-colors cursor-pointer">
+                <button className="bg-gray-300 text-gray-500 px-8 py-3 rounded-full font-semibold text-lg cursor-not-allowed" disabled>
                   Buy ${creator.symbol} (coming soon)
                 </button>
               </div>
@@ -447,15 +447,20 @@ export default function CreatorPage() {
 
                         {/* Action Button */}
                         <button 
-                          className="w-full py-2 px-4 rounded-full font-semibold text-sm transition-colors cursor-pointer bg-black text-white hover:bg-gray-800"
+                          className={`w-full py-2 px-4 rounded-full font-semibold text-sm transition-colors ${
+                            isUnlocked 
+                              ? 'cursor-pointer bg-black text-white hover:bg-gray-800' 
+                              : 'cursor-not-allowed bg-gray-300 text-gray-500'
+                          }`}
                           onClick={() => {
                             if (isUnlocked) {
                               setSelectedContent(content);
                               setIsModalOpen(true);
                             }
                           }}
+                          disabled={!isUnlocked}
                         >
-                          {isUnlocked ? 'View Content' : `Buy ${requiredBalance} $${creator.symbol}`}
+                          {isUnlocked ? 'View Content' : `Buy $${creator.symbol} (coming soon)`}
                         </button>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Disabled all buy buttons in the application with a "coming soon" indicator
- Improved UI clarity by removing confusion about non-functional purchase features

## Changes
- Updated main Buy button styling to be greyed out (bg-gray-300, text-gray-500) with disabled state
- Made content Buy buttons conditionally styled - greyed out when content is locked
- Added '(coming soon)' text to all buy buttons that didn't already have it
- Removed token amounts from content buy button text for cleaner UI presentation
- All buy buttons now properly indicate that purchasing functionality is not yet available

## Test plan
- [x] Verify main Buy button appears greyed out with "coming soon" text
- [x] Verify content Buy buttons are greyed out for locked content
- [x] Verify buttons are properly disabled (not clickable)
- [x] Verify "View Content" buttons still work for unlocked content
- [x] Check button visibility on light backgrounds

🤖 Generated with [Claude Code](https://claude.ai/code)