### PR TITLE
Fix profile image display across the application

### DIFF
--- a/components/UI/CreatorAvatar.tsx
+++ b/components/UI/CreatorAvatar.tsx
@@ -17,45 +17,37 @@ const CreatorAvatar: React.FC<CreatorAvatarProps> = ({
   size = 48 
 }) => {
   const [imageError, setImageError] = useState(false);
-  const [imageLoaded, setImageLoaded] = useState(false);
 
   const handleImageError = () => {
     setImageError(true);
   };
 
-  const handleImageLoad = () => {
-    setImageLoaded(true);
-  };
-
-  // Show fallback if no src, image failed to load, or image hasn't loaded yet
-  const showFallback = !src || imageError || !imageLoaded;
+  // Show fallback only if no src or image failed to load
+  const showFallback = !src || imageError;
 
   return (
-    <div className="relative" style={{ width: size, height: size }}>
-      {src && !imageError && (
+    <div className="relative rounded-full overflow-hidden" style={{ width: size, height: size }}>
+      {src && !imageError ? (
         <Image
           src={src}
           alt={alt}
           fill
-          className="rounded-full object-cover"
+          className="object-cover"
           onError={handleImageError}
-          onLoad={handleImageLoad}
-          style={{ display: imageLoaded ? 'block' : 'none' }}
+          unoptimized
         />
-      )}
-      
-      {/* Fallback gradient avatar */}
-      <div 
-        className={`bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center ${showFallback ? '' : 'hidden'}`}
-        style={{ width: size, height: size }}
-      >
-        <span 
-          className="text-white font-bold" 
-          style={{ fontSize: Math.max(12, size / 3) }}
+      ) : (
+        <div 
+          className="bg-gradient-to-br from-blue-500 to-purple-500 flex items-center justify-center w-full h-full"
         >
-          {symbol.charAt(0).toUpperCase()}
-        </span>
-      </div>
+          <span 
+            className="text-white font-bold" 
+            style={{ fontSize: Math.max(12, size / 3) }}
+          >
+            {symbol.charAt(0).toUpperCase()}
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/lib/hooks/useZoraCreators.ts
+++ b/lib/hooks/useZoraCreators.ts
@@ -95,7 +95,7 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
         description: coin?.description || 'Creator on Zora',
         profileImage: coin?.mediaContent?.previewImage?.medium || 
                      coin?.mediaContent?.previewImage?.small || 
-                     `/api/placeholder/150/150`,
+                     undefined,
         totalSupply: coin?.totalSupply || '0',
         marketCap: coin?.marketCap || '0',
         uniqueHolders: coin?.uniqueHolders || 0,
@@ -171,7 +171,7 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
           description: coin.description || 'Creator on Zora',
           profileImage: coin.mediaContent?.previewImage?.medium || 
                        coin.mediaContent?.previewImage?.small || 
-                       `/api/placeholder/150/150`,
+                       undefined,
           totalSupply: coin.totalSupply || '0',
           marketCap: coin.marketCap || '0',
           uniqueHolders: coin.uniqueHolders || 0,

--- a/lib/hooks/useZoraCreators.ts
+++ b/lib/hooks/useZoraCreators.ts
@@ -93,7 +93,13 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
         name: coin?.name || 'Unknown Creator',
         symbol: coin?.symbol || 'UNKNOWN',
         description: coin?.description || 'Creator on Zora',
-        profileImage: coin?.mediaContent?.previewImage?.medium || 
+        profileImage: coin?.avatarUrl || 
+                     coin?.imageUrl || 
+                     coin?.image || 
+                     coin?.avatar || 
+                     coin?.mediaContent?.avatar || 
+                     coin?.mediaContent?.image || 
+                     coin?.mediaContent?.previewImage?.medium || 
                      coin?.mediaContent?.previewImage?.small || 
                      undefined,
         totalSupply: coin?.totalSupply || '0',
@@ -144,6 +150,15 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
       if (response.data?.zora20Token) {
         const coin = response.data.zora20Token;
         
+        // Debug the mediaContent structure
+        console.log('=== MEDIA CONTENT DEBUG ===');
+        console.log('Full coin object:', JSON.stringify(coin, null, 2));
+        console.log('MediaContent:', coin.mediaContent);
+        console.log('PreviewImage:', coin.mediaContent?.previewImage);
+        console.log('Avatar URL:', coin.avatarUrl);
+        console.log('Image URL:', coin.imageUrl);
+        console.log('Profile Image:', coin.profileImage);
+        
         // Get user's balance for this coin
         console.log('=== GETTING USER BALANCE IN getCreatorById ===');
         console.log('Looking for coinAddress:', coinAddress);
@@ -169,7 +184,13 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
           name: coin.name || 'Unknown Creator',
           symbol: coin.symbol || 'UNKNOWN',
           description: coin.description || 'Creator on Zora',
-          profileImage: coin.mediaContent?.previewImage?.medium || 
+          profileImage: coin.avatarUrl || 
+                       coin.imageUrl || 
+                       coin.image || 
+                       coin.avatar || 
+                       coin.mediaContent?.avatar || 
+                       coin.mediaContent?.image || 
+                       coin.mediaContent?.previewImage?.medium || 
                        coin.mediaContent?.previewImage?.small || 
                        undefined,
           totalSupply: coin.totalSupply || '0',

--- a/lib/hooks/useZoraCreators.ts
+++ b/lib/hooks/useZoraCreators.ts
@@ -93,15 +93,8 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
         name: coin?.name || 'Unknown Creator',
         symbol: coin?.symbol || 'UNKNOWN',
         description: coin?.description || 'Creator on Zora',
-        profileImage: coin?.avatarUrl || 
-                     coin?.imageUrl || 
-                     coin?.image || 
-                     coin?.avatar || 
-                     coin?.mediaContent?.avatar || 
-                     coin?.mediaContent?.image || 
-                     coin?.mediaContent?.previewImage?.medium || 
-                     coin?.mediaContent?.previewImage?.small || 
-                     undefined,
+        profileImage: coin?.mediaContent?.previewImage?.medium || 
+                     coin?.mediaContent?.previewImage?.small,
         totalSupply: coin?.totalSupply || '0',
         marketCap: coin?.marketCap || '0',
         uniqueHolders: coin?.uniqueHolders || 0,
@@ -150,15 +143,6 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
       if (response.data?.zora20Token) {
         const coin = response.data.zora20Token;
         
-        // Debug the mediaContent structure
-        console.log('=== MEDIA CONTENT DEBUG ===');
-        console.log('Full coin object:', JSON.stringify(coin, null, 2));
-        console.log('MediaContent:', coin.mediaContent);
-        console.log('PreviewImage:', coin.mediaContent?.previewImage);
-        console.log('Avatar URL:', coin.avatarUrl);
-        console.log('Image URL:', coin.imageUrl);
-        console.log('Profile Image:', coin.profileImage);
-        
         // Get user's balance for this coin
         console.log('=== GETTING USER BALANCE IN getCreatorById ===');
         console.log('Looking for coinAddress:', coinAddress);
@@ -184,15 +168,8 @@ export const useZoraCreators = (): UseZoraCreatorsReturn => {
           name: coin.name || 'Unknown Creator',
           symbol: coin.symbol || 'UNKNOWN',
           description: coin.description || 'Creator on Zora',
-          profileImage: coin.avatarUrl || 
-                       coin.imageUrl || 
-                       coin.image || 
-                       coin.avatar || 
-                       coin.mediaContent?.avatar || 
-                       coin.mediaContent?.image || 
-                       coin.mediaContent?.previewImage?.medium || 
-                       coin.mediaContent?.previewImage?.small || 
-                       undefined,
+          profileImage: coin.mediaContent?.previewImage?.medium || 
+                       coin.mediaContent?.previewImage?.small,
           totalSupply: coin.totalSupply || '0',
           marketCap: coin.marketCap || '0',
           uniqueHolders: coin.uniqueHolders || 0,


### PR DESCRIPTION
## Summary
- Fixed profile images not displaying on creator profile pages and admin dashboard
- Images were being retrieved correctly from Zora API but not rendered due to component logic issue

## Changes
- **Simplified CreatorAvatar component**: Removed the `imageLoaded` state that was preventing images from displaying
- **Fixed image retrieval**: Corrected the profileImage field mapping to use `mediaContent.previewImage.medium/small`
- **Improved component logic**: Now displays images immediately like the working TopCreators component
- **Better fallback handling**: Shows gradient avatar only when image URL is missing or fails to load

## Technical Details
The issue was that CreatorAvatar was waiting for an `onLoad` event before showing images, but was hiding them until then with `display: none`. This prevented the load event from firing properly. The fix removes this unnecessary state management and shows images immediately.

## Test plan
- [x] Verify profile images display on creator profile pages
- [x] Verify profile images display in admin dashboard
- [x] Verify fallback gradient avatar shows for creators without images
- [x] Verify images continue to work on homepage (TopCreators)
- [x] Test with multiple creator profiles

🤖 Generated with [Claude Code](https://claude.ai/code)