### PR TITLE
Remove toast notifications for wallet connectivity

### DIFF
--- a/lib/hooks/useZoraLinking.ts
+++ b/lib/hooks/useZoraLinking.ts
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { usePrivy, useCrossAppAccounts } from '@privy-io/react-auth';
-import { toast } from 'sonner';
 import { getProfileBalances } from '@zoralabs/coins-sdk';
 import { ethers } from 'ethers';
 
@@ -201,7 +200,6 @@ export const useZoraLinking = (): UseZoraLinkingReturn => {
     }
 
     if (hasZoraLinked) {
-      toast.info('Zora account already linked');
       return;
     }
 
@@ -229,7 +227,6 @@ export const useZoraLinking = (): UseZoraLinkingReturn => {
         throw new Error(errorData.error || 'Failed to save Zora linking information');
       }
 
-      toast.success('Zora account linked successfully!');
       
       // Refetch the stored wallet data
       const walletResponse = await fetch('/api/user/zora-wallet', {
@@ -262,7 +259,6 @@ export const useZoraLinking = (): UseZoraLinkingReturn => {
       }
       
       setError(errorMessage);
-      toast.error(errorMessage);
     } finally {
       setIsLinking(false);
     }
@@ -290,7 +286,6 @@ export const useZoraLinking = (): UseZoraLinkingReturn => {
         throw new Error(errorData.error || 'Failed to clear Zora linking');
       }
 
-      toast.success('Zora linking cleared successfully!');
       
       // Clear stored wallet data
       setStoredZoraWallet(null);
@@ -306,7 +301,6 @@ export const useZoraLinking = (): UseZoraLinkingReturn => {
       }
       
       setError(errorMessage);
-      toast.error(errorMessage);
     } finally {
       setIsClearing(false);
     }


### PR DESCRIPTION
## Summary
- Removed Sonner toast popup notifications that appear after wallet connectivity actions
- Toast notifications no longer appear for Zora wallet linking/unlinking operations
- Error messages are still captured in component state for display in the ZoraLinkingModal

## Changes
- Removed `toast` import from `sonner` in useZoraLinking hook
- Removed all `toast.info()`, `toast.success()`, and `toast.error()` calls related to wallet connectivity
- Preserved error state management via `setError()` for modal display

## Test plan
- [ ] Test linking Zora wallet - should not show toast notifications
- [ ] Test when Zora wallet is already linked - should not show info toast
- [ ] Test error scenarios - errors should still display in modal but not as toasts
- [ ] Test clearing Zora link - should not show success toast

🤖 Generated with [Claude Code](https://claude.ai/code)